### PR TITLE
suggested changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/csimplestring/go-left-right
 
 go 1.15
+
+require github.com/tevino/abool v1.2.0

--- a/lrmap/map.go
+++ b/lrmap/map.go
@@ -1,21 +1,24 @@
-package lrc
+package lrmap
+
+import "github.com/csimplestring/go-left-right/primitive"
 
 // LRMap utilises the left-right pattern to handle concurrent read-write.
 type LRMap struct {
-	*LeftRightPrimitive
+	*primitive.LeftRightPrimitive
 
 	left  map[int]int
 	right map[int]int
 }
 
-func newIntMap() *LRMap {
+// NewIntMap creates a default LRMap
+func NewIntMap() *LRMap {
 
 	m := &LRMap{
 		left:  make(map[int]int),
 		right: make(map[int]int),
 	}
 
-	m.LeftRightPrimitive = New()
+	m.LeftRightPrimitive = primitive.New()
 
 	return m
 }

--- a/lrmap/map_bench_test.go
+++ b/lrmap/map_bench_test.go
@@ -1,4 +1,4 @@
-package lrc
+package lrmap
 
 import (
 	"math/rand"
@@ -45,7 +45,7 @@ func InitLockMap(num int) *LockMap {
 }
 
 func InitLRMap(num int) *LRMap {
-	lrmap := newIntMap()
+	lrmap := NewIntMap()
 
 	for i := 0; i < num; i++ {
 		lrmap.Put(i, i)

--- a/lrmap/map_test.go
+++ b/lrmap/map_test.go
@@ -1,11 +1,11 @@
-package lrc
+package lrmap
 
 import (
 	"testing"
 )
 
 func TestLRMap(t *testing.T) {
-	lrmap := newIntMap()
+	lrmap := NewIntMap()
 
 	_, exist := lrmap.Get(1)
 	if exist {

--- a/primitive/read_indicator.go
+++ b/primitive/read_indicator.go
@@ -1,4 +1,4 @@
-package lrc
+package primitive
 
 import "sync/atomic"
 


### PR DESCRIPTION
A testrun and tried out tevino/abool in stead of atomic int.

you have a bug in ApplyWriteFn which is attached to the LRMap, not the primitive

I moved the code into folders, this also fixed having to rename import as you'd have to with using the root (dashes in the repo name)

GL