### PR TITLE
moves primitives to package primitive

### DIFF
--- a/map.go
+++ b/map.go
@@ -1,8 +1,10 @@
 package lrc
 
+import "github.com/csimplestring/go-left-right/primitive"
+
 // LRMap utilises the left-right pattern to handle concurrent read-write.
 type LRMap struct {
-	*LeftRightPrimitive
+	*primitive.LeftRightPrimitive
 
 	left  map[int]int
 	right map[int]int
@@ -15,7 +17,7 @@ func newIntMap() *LRMap {
 		right: make(map[int]int),
 	}
 
-	m.LeftRightPrimitive = New()
+	m.LeftRightPrimitive = primitive.New()
 
 	return m
 }

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -36,20 +36,20 @@ func New() *LeftRightPrimitive {
 	return m
 }
 
-// ReaderArrive shall be called by the reader goroutine before start reading
-func (lr *LeftRightPrimitive) ReaderArrive() int {
+// readerArrive shall be called by the reader goroutine before start reading
+func (lr *LeftRightPrimitive) readerArrive() int {
 	idx := atomic.LoadInt32(lr.versionIndex)
 	lr.readIndicators[idx].arrive()
 	return int(idx)
 }
 
-// ReaderDepart shall be called by the reader goroutine after finish reading
-func (lr *LeftRightPrimitive) ReaderDepart(localVI int) {
+// readerDepart shall be called by the reader goroutine after finish reading
+func (lr *LeftRightPrimitive) readerDepart(localVI int) {
 	lr.readIndicators[localVI].depart()
 }
 
-// WriterToggleVersionAndWait shall be called by a single writer goroutine when applying the modification
-func (lr *LeftRightPrimitive) WriterToggleVersionAndWait() {
+// writerToggleVersionAndWait shall be called by a single writer goroutine when applying the modification
+func (lr *LeftRightPrimitive) writerToggleVersionAndWait() {
 
 	localVI := atomic.LoadInt32(lr.versionIndex)
 	prevVI := int(localVI % 2)
@@ -72,7 +72,7 @@ func (lr *LeftRightPrimitive) WriterToggleVersionAndWait() {
 // ApplyReadFn applies read operation on the chosen instance, oh, I really need generics, interface type is ugly
 func (lr *LeftRightPrimitive) ApplyReadFn(l interface{}, r interface{}, fn func(interface{})) {
 
-	lvi := lr.ReaderArrive()
+	lvi := lr.readerArrive()
 
 	which := atomic.LoadInt32(lr.sideToRead)
 	if which == ReadOnLeft {
@@ -81,7 +81,7 @@ func (lr *LeftRightPrimitive) ApplyReadFn(l interface{}, r interface{}, fn func(
 		fn(r)
 	}
 
-	lr.ReaderDepart(lvi)
+	lr.readerDepart(lvi)
 	return
 }
 
@@ -94,13 +94,13 @@ func (lr *LeftRightPrimitive) ApplyWriteFn(l interface{}, r interface{}, fn func
 		// write on right
 		fn(r)
 		atomic.StoreInt32(lr.sideToRead, ReadOnRight)
-		lr.WriterToggleVersionAndWait()
+		lr.writerToggleVersionAndWait()
 		fn(l)
 	} else if side == ReadOnRight {
 		// write on left
 		fn(l)
 		atomic.StoreInt32(lr.sideToRead, ReadOnLeft)
-		lr.WriterToggleVersionAndWait()
+		lr.writerToggleVersionAndWait()
 		fn(r)
 	} else {
 		panic("illegal state: you can only read on LEFT or RIGHT")

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -1,4 +1,4 @@
-package lrc
+package primitive
 
 import (
 	"runtime"
@@ -87,7 +87,7 @@ func (lr *LeftRightPrimitive) ApplyReadFn(l interface{}, r interface{}, fn func(
 
 // ApplyWriteFn applies write operation on the chosen instance, write operation is done twice, on the left and right
 // instance respectively, this might make writing longer, but the readers are wait-free.
-func (lr *LRMap) ApplyWriteFn(l interface{}, r interface{}, fn func(interface{})) {
+func (lr *LeftRightPrimitive) ApplyWriteFn(l interface{}, r interface{}, fn func(interface{})) {
 
 	side := atomic.LoadInt32(lr.sideToRead)
 	if side == ReadOnLeft {

--- a/primitive/read_indicator.go
+++ b/primitive/read_indicator.go
@@ -1,4 +1,4 @@
-package lrc
+package primitive
 
 import "sync/atomic"
 


### PR DESCRIPTION
fixes requiring namespace overriding of this package as an import

```go
import primitive "github.com/csimplestring/go-left-right"
```
becomes
```go
import "github.com/csimplestring/go-left-right/primitive"
```

This also had to fix the issue that I have addressed in my earlier PR (moving to primitive) exposes the bug