### PR TITLE
New reader indicator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/csimplestring/go-left-right
 
 go 1.15
+
+require github.com/linxGnu/go-adder v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/linxGnu/go-adder v0.2.0 h1:5vI8SeW5Lz4xmRbf3lFYfTs+8cRUWjZEr5YvdToBqPc=
+github.com/linxGnu/go-adder v0.2.0/go.mod h1:t9zC6P+vQpG5iEtw4sinwsVqe52AuFvL4P1dVXHD46c=
+github.com/valyala/fastrand v1.0.0 h1:LUKT9aKer2dVQNUi3waewTbKV+7H17kvWFNKs2ObdkI=
+github.com/valyala/fastrand v1.0.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=

--- a/map_bench_test.go
+++ b/map_bench_test.go
@@ -178,3 +178,19 @@ func BenchmarkLockMap_Read_Write_100_1(b *testing.B) {
 		run(m, 100)
 	}
 }
+
+func BenchmarkLRMap_Read_Write_500_1(b *testing.B) {
+	m := InitLRMap(test_entry_size)
+
+	for i := 0; i < b.N; i++ {
+		run(m, 500)
+	}
+}
+
+func BenchmarkLockMap_Read_Write_500_1(b *testing.B) {
+	m := InitLockMap(test_entry_size)
+
+	for i := 0; i < b.N; i++ {
+		run(m, 100)
+	}
+}

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -11,7 +11,7 @@ const ReadOnRight int32 = 1
 // LeftRightPrimitive provides the basic core of the leftt-right pattern.
 type LeftRightPrimitive struct {
 	// readIndicators is an array of 2 read-indicators, counting the reader numbers on the left/right instance
-	readIndicators [2]*readIndicator
+	readIndicators [2]ReadIndicator
 	// versionIndex is the index for readIndicators, 0 means reading on left, 1 means reading on right
 	versionIndex *int32
 	// sideToRead represents which instance to read
@@ -22,9 +22,9 @@ type LeftRightPrimitive struct {
 func New() *LeftRightPrimitive {
 
 	m := &LeftRightPrimitive{
-		readIndicators: [2]*readIndicator{
-			newReadIndicator(),
-			newReadIndicator(),
+		readIndicators: [2]ReadIndicator{
+			newDistributedAtomicReadIndicator(),
+			newDistributedAtomicReadIndicator(),
 		},
 		versionIndex: new(int32),
 		sideToRead:   new(int32),

--- a/primitive/read_indicator.go
+++ b/primitive/read_indicator.go
@@ -1,15 +1,49 @@
 package primitive
 
-import "sync/atomic"
+import (
+	"sync/atomic"
 
-// readIndicator uses an int32 as the counter to count the readers
-type readIndicator struct {
+	g "github.com/linxGnu/go-adder"
+)
+
+type ReadIndicator interface {
+	arrive()
+	depart()
+	isEmpty() bool
+}
+
+type distributedAtomicReadIndicator struct {
+	ingress g.LongAdder
+	egress  g.LongAdder
+}
+
+func newDistributedAtomicReadIndicator() *distributedAtomicReadIndicator {
+	return &distributedAtomicReadIndicator{
+		ingress: g.NewJDKAdder(),
+		egress:  g.NewJDKAdder(),
+	}
+}
+
+func (d *distributedAtomicReadIndicator) arrive() {
+	d.ingress.Inc()
+}
+
+func (d *distributedAtomicReadIndicator) depart() {
+	d.egress.Inc()
+}
+
+func (d *distributedAtomicReadIndicator) isEmpty() bool {
+	return d.egress.Sum() == d.ingress.Sum()
+}
+
+// atomicReadIndicator uses an int32 as the counter to count the readers
+type atomicReadIndicator struct {
 	count *int32
 }
 
-// newReadIndicator creates a readIndicator
-func newReadIndicator() *readIndicator {
-	r := &readIndicator{
+// newAtomicReadIndicator creates a readIndicator
+func newAtomicReadIndicator() *atomicReadIndicator {
+	r := &atomicReadIndicator{
 		count: new(int32),
 	}
 	*r.count = 0
@@ -17,16 +51,16 @@ func newReadIndicator() *readIndicator {
 }
 
 // arrive should be called by the reader goroutine when start reading, increments the counter
-func (r *readIndicator) arrive() {
+func (r *atomicReadIndicator) arrive() {
 	atomic.AddInt32(r.count, 1)
 }
 
 // depart should be called by the reader goroutine when finish reading, decrements the counter
-func (r *readIndicator) depart() {
+func (r *atomicReadIndicator) depart() {
 	atomic.AddInt32(r.count, -1)
 }
 
 // isEmpty returns true if no readers
-func (r *readIndicator) isEmpty() bool {
+func (r *atomicReadIndicator) isEmpty() bool {
 	return atomic.LoadInt32(r.count) == 0
 }


### PR DESCRIPTION
In this PR, a new technique called 'ingress/egress' is used to reduce the read contention on the read-indicator. The core idea is to use the LongAdder (similar JDK LongAdder), which spread the contention in different cells. This is very useful and scalable when there are too many readers. 

The benchmark comparison results are: 

``` Go
Benchmark-LongAdder-LRMap_Read_Write_100_1       	     249	   4649508 ns/op	     707 B/op	       1 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_100_1-2     	     172	   7267487 ns/op	    1055 B/op	       2 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_100_1-4     	     254	   4801497 ns/op	     975 B/op	       3 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_100_1-8     	     315	   3792883 ns/op	    1004 B/op	       4 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_500_1       	      66	  23151452 ns/op	    2647 B/op	       3 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_500_1-2     	      33	  40375654 ns/op	    5535 B/op	       7 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_500_1-4     	      46	  24362344 ns/op	    6045 B/op	      18 allocs/op
Benchmark-LongAdder-LRMap_Read_Write_500_1-8     	      67	  17489811 ns/op	    5068 B/op	      17 allocs/op


Benchmark-AtomicAdder-LRMap_Read_Write_100_1       	     368	   3177685 ns/op	     481 B/op	       1 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_100_1-2     	     174	   6815903 ns/op	    1011 B/op	       1 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_100_1-4     	     181	   6525143 ns/op	     973 B/op	       1 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_100_1-8     	     201	   6011937 ns/op	     922 B/op	       1 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_500_1       	      75	  15888525 ns/op	    2306 B/op	       2 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_500_1-2     	      31	  33664236 ns/op	    5605 B/op	       5 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_500_1-4     	      34	  32456822 ns/op	    5108 B/op	       5 allocs/op
Benchmark-AtomicAdder-LRMap_Read_Write_500_1-8     	      38	  31595880 ns/op	    5873 B/op	       8 allocs/op

```

As is shown, the throughput is linear along with the cpu core number and the LongAdder is more scalable then AtomicAdder.  